### PR TITLE
Add skills path to plugin.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,5 +4,6 @@
     "version": "0.0.1",
     "author": {
         "name": "Microsoft Corporation"
-    }
+    },
+    "skills": ["./skills/ilspy-decompile"]
 }


### PR DESCRIPTION
## Summary
- Adds the `skills` array to `plugin.json` so Claude Code can discover skills when using this repo as a submodule/plugin
- Without this field, Claude Code doesn't know where to look for skill definitions

## Context
The `marketplace.json` correctly lists the plugin, but `plugin.json` is missing the `skills` entry that Claude Code uses for skill discovery. This is the same issue that was fixed in [andrej-karpathy-skills#18](https://github.com/forrestchang/andrej-karpathy-skills/pull/18).

## Test plan
- [ ] Add repo as a Claude Code plugin/submodule
- [ ] Verify `ilspy-decompile` skill is discovered and available

🤖 Generated with [Claude Code](https://claude.com/claude-code)